### PR TITLE
add restart channel

### DIFF
--- a/vprint.go
+++ b/vprint.go
@@ -5,8 +5,8 @@ import (
 	"time"
 )
 
-var Verbose bool // set to true to debug
-var Working bool // currently under investigation
+var Verbose bool = true // set to true to debug
+var Working bool = true // currently under investigation
 
 var V = VPrintf
 var W = WPrintf
@@ -15,7 +15,9 @@ func P(format string, stuff ...interface{}) {
 	fmt.Printf("\n "+format+"\n", stuff...)
 }
 
-func Q(quietly_ignored ...interface{}) {} // quiet
+func Q(format string, quietly_ignored ...interface{}) { // quiet
+	fmt.Printf("\n "+format+"\n", quietly_ignored...)
+}
 
 // get timestamp for logging purposes
 func ts() string {

--- a/watchdog.go
+++ b/watchdog.go
@@ -156,6 +156,7 @@ func (w *Watchdog) Start() {
 				w.proc, err = os.StartProcess(w.PathToChildExecutable, w.Args, &w.Attr)
 				if err != nil {
 					w.err = err
+					Q(" debug: unable to start: %v", w.err)
 					return
 				}
 				w.curPid = w.proc.Pid

--- a/watchdog.go
+++ b/watchdog.go
@@ -1,16 +1,18 @@
 package bark
 
 import (
-	"time"
-	"bytes"
-	"os/exec"
-	"fmt"
 	"log"
+	"bytes"
+	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 )
+
+type WatchdogLogFunc func(format string, a ...interface{})
 
 type Watchdog struct {
 	Ready                    chan bool
@@ -21,26 +23,29 @@ type Watchdog struct {
 	CurrentPid               chan int
 	curPid                   int
 
+	Logger WatchdogLogFunc
+	EnableDebugLogging bool
+
 	startCount int64
 
-	MaxRetries int
-	retryCount int
-	RetryInterval time.Duration
-	DeclareSuccessInterval time.Duration  // time after which process is declared successfully (re)started
+	MaxRetries             int
+	retryCount             int
+	RetryInterval          time.Duration
+	DeclareSuccessInterval time.Duration // time after which process is declared successfully (re)started
 
 	mut      sync.Mutex
 	shutdown bool
 
 	PathToChildExecutable string
-	Cwd string
+	Cwd                   string
 	Args                  []string
 	// Attr                  os.ProcAttr
-	err                   error
-	needRestart           bool
-	cmd                   *exec.Cmd
-	exitAfterReaping      bool
-	sout bytes.Buffer
-	serr bytes.Buffer
+	err              error
+	needRestart      bool
+	cmd              *exec.Cmd
+	exitAfterReaping bool
+	sout             bytes.Buffer
+	serr             bytes.Buffer
 }
 
 // NewWatchdog creates a Watchdog structure but
@@ -68,11 +73,11 @@ func NewWatchdog(
 		RestartChild:             make(chan bool),
 		ReqStopWatchdog:          make(chan bool),
 		TermChildAndStopWatchdog: make(chan bool),
-		Done:       make(chan bool),
-		CurrentPid: make(chan int),
-		Cwd: cwd,
-		MaxRetries: 10,
-		RetryInterval: 5 * time.Second,
+		Done:                   make(chan bool),
+		CurrentPid:             make(chan int),
+		Cwd:                    cwd,
+		MaxRetries:             10,
+		RetryInterval:          5 * time.Second,
 		DeclareSuccessInterval: 10 * time.Second,
 	}
 
@@ -138,6 +143,18 @@ func (w *Watchdog) GetErr() error {
 	return w.err
 }
 
+func (w *Watchdog) logEvent(isDebug bool, format string, a ...interface{}) {
+	if !w.EnableDebugLogging && isDebug {
+		return
+	}
+
+	if w.Logger != nil {
+		w.Logger(format, a...)
+	} else {
+		log.Printf(format, a...)
+	}
+}
+
 // see w.err for any error after w.Done
 func (w *Watchdog) Start() {
 
@@ -165,7 +182,7 @@ func (w *Watchdog) Start() {
 		for {
 			w.mut.Lock()
 			if w.retryCount > w.MaxRetries {
-				Q(" debug: unable to start after %v retries, giving up", w.retryCount)
+				w.logEvent(true, " debug: unable to start after %v retries, giving up", w.retryCount)
 				w.err = fmt.Errorf("unable to start process after %v retries, giving up", w.retryCount)
 				return
 			}
@@ -175,12 +192,12 @@ func (w *Watchdog) Start() {
 				if w.cmd != nil && w.cmd.Process != nil {
 					w.cmd.Process.Release()
 				}
-				Q(" debug: about to start '%s'", w.PathToChildExecutable)
+				w.logEvent(true, " debug: about to start '%s'", w.PathToChildExecutable)
 				//w.cmd.SysProcAttr = &w.Attr;
 
 				w.mut.Lock()
 				if w.retryCount > 0 {
-					Q("Sleeping for %v before attempting restart; retryCount = %v (max = %v)", w.RetryInterval, w.retryCount, w.MaxRetries)
+					w.logEvent(true, "Sleeping for %v before attempting restart; retryCount = %v (max = %v)", w.RetryInterval, w.retryCount, w.MaxRetries)
 					time.Sleep(w.RetryInterval)
 				}
 				w.mut.Unlock()
@@ -194,7 +211,7 @@ func (w *Watchdog) Start() {
 				err = w.cmd.Start()
 				if err != nil {
 					w.err = err
-					Q(" debug: unable to start: '%v' '%v' '%v'", w.err, w.sout.String(), w.serr.String())
+					w.logEvent(true, " debug: unable to start: '%v' '%v' '%v'", w.err, w.sout.String(), w.serr.String())
 					return
 				}
 				w.curPid = w.cmd.Process.Pid
@@ -215,39 +232,39 @@ func (w *Watchdog) Start() {
 				}(w.retryCount)
 				w.mut.Unlock()
 
-				Q(" Start number %d: Watchdog started pid %d / new process '%s'", w.startCount, w.cmd.Process.Pid, w.PathToChildExecutable)
+				w.logEvent(true, " Start number %d: Watchdog started pid %d / new process '%s'", w.startCount, w.cmd.Process.Pid, w.PathToChildExecutable)
 			}
 
 			select {
 			case w.CurrentPid <- w.curPid:
 			case <-w.TermChildAndStopWatchdog:
-				Q(" TermChildAndStopWatchdog noted, exiting watchdog.Start() loop")
+				w.logEvent(true, " TermChildAndStopWatchdog noted, exiting watchdog.Start() loop")
 
 				err := w.cmd.Process.Signal(syscall.SIGKILL)
 				if err != nil {
 					err = fmt.Errorf("warning: watchdog tried to SIGKILL pid %d but got error: '%s'", w.cmd.Process.Pid, err)
 					w.SetErr(err)
-					log.Printf("%s", err)
+					w.logEvent(false, "%s", err)
 					return
 				}
 				w.exitAfterReaping = true
 				continue reaploop
 			case <-w.ReqStopWatchdog:
-				Q(" ReqStopWatchdog noted, exiting watchdog.Start() loop")
+				w.logEvent(true, " ReqStopWatchdog noted, exiting watchdog.Start() loop")
 				return
 			case <-w.RestartChild:
-				Q(" debug: got <-w.RestartChild")
+				w.logEvent(true, " debug: got <-w.RestartChild")
 				err := w.cmd.Process.Signal(syscall.SIGKILL)
 				if err != nil {
 					err = fmt.Errorf("warning: watchdog tried to SIGKILL pid %d but got error: '%s'", w.cmd.Process.Pid, err)
 					w.SetErr(err)
-					log.Printf("%s", err)
+					w.logEvent(false, "%s", err)
 					return
 				}
 				w.curPid = 0
 				continue reaploop
 			case <-signalChild:
-				Q(" debug: got <-signalChild")
+				w.logEvent(true, " debug: got <-signalChild")
 
 				for i := 0; i < 1000; i++ {
 					pid, err := syscall.Wait4(w.cmd.Process.Pid, &ws, syscall.WNOHANG, nil)
@@ -257,18 +274,18 @@ func (w *Watchdog) Start() {
 					// pid -1 && errno == ECHILD => no new status children
 					// pid -1 && errno != ECHILD => syscall interupped by signal
 					// pid == 0 => no more children to wait for.
-					Q(" pid=%v  ws=%v and err == %v", pid, ws, err)
+					w.logEvent(true, " pid=%v  ws=%v and err == %v", pid, ws, err)
 					switch {
 					case err != nil:
 						err = fmt.Errorf("wait4() got error back: '%s' and ws:%v", err, ws)
-						log.Printf("warning in reaploop, wait4(WNOHANG) returned error: '%s'. ws=%v", err, ws)
+						w.logEvent(false, "warning in reaploop, wait4(WNOHANG) returned error: '%s'. ws=%v", err, ws)
 						w.SetErr(err)
 						continue reaploop
 					case pid == w.cmd.Process.Pid:
-						Q(" Watchdog saw OUR current w.cmd.Process.Pid %d/process '%s' finish with waitstatus: %v.", pid, w.PathToChildExecutable, ws)
-						Q(" stdout: '%v'\nstderr: '%v'\n", w.sout.String(), w.serr.String())
+						w.logEvent(true, " Watchdog saw OUR current w.cmd.Process.Pid %d/process '%s' finish with waitstatus: %v.", pid, w.PathToChildExecutable, ws)
+						w.logEvent(true, " stdout: '%v'\nstderr: '%v'\n", w.sout.String(), w.serr.String())
 						if w.exitAfterReaping {
-							Q("watchdog sees exitAfterReaping. exiting now.")
+							w.logEvent(true, "watchdog sees exitAfterReaping. exiting now.")
 							return
 						}
 						w.needRestart = true
@@ -279,15 +296,15 @@ func (w *Watchdog) Start() {
 						// Note that on OSX we never get a SIGCONT signal.
 						// Under WNOHANG, pid == 0 means there is nobody left to wait for,
 						// so just go back to waiting for another SIGCHLD.
-						Q("pid == 0 on wait4, (perhaps SIGSTOP?): nobody left to wait for, keep looping. ws = %v", ws)
+						w.logEvent(true, "pid == 0 on wait4, (perhaps SIGSTOP?): nobody left to wait for, keep looping. ws = %v", ws)
 						continue reaploop
 					default:
-						Q(" warning in reaploop: wait4() negative or not our pid, sleep and try again")
+						w.logEvent(true, " warning in reaploop: wait4() negative or not our pid, sleep and try again")
 						time.Sleep(time.Millisecond)
 					}
 				} // end for i
 				w.SetErr(fmt.Errorf("could not reap child PID %d or obtain wait4(WNOHANG)==0 even after 1000 attempts", w.cmd.Process.Pid))
-				log.Printf("%s", w.err)
+				w.logEvent(false, "%s", w.err)
 				return
 			} // end select
 		} // end for reaploop

--- a/watchdog.go
+++ b/watchdog.go
@@ -284,8 +284,8 @@ func (w *Watchdog) Start() {
 						w.SetErr(err)
 						continue reaploop
 					case pid == w.cmd.Process.Pid:
-						w.logEvent(true, " saw OUR current w.cmd.Process.Pid %d/process '%s' finish with waitstatus: %v.", pid, w.PathToChildExecutable, ws)
-						w.logEvent(true, "Watchdog:\nstdout: '%v'\nstderr: '%v'\n", w.sout.String(), w.serr.String())
+						w.logEvent(true, "saw OUR current w.cmd.Process.Pid %d/process '%s' finish with waitstatus: %v.", pid, w.PathToChildExecutable, ws)
+						w.logEvent(true, "\nstdout: '%v'\nstderr: '%v'\n", w.sout.String(), w.serr.String())
 						if w.exitAfterReaping {
 							w.logEvent(true, "sees exitAfterReaping. exiting now.")
 							return

--- a/watchdog.go
+++ b/watchdog.go
@@ -234,7 +234,7 @@ func (w *Watchdog) Start() {
 				}(w.retryCount)
 				w.mut.Unlock()
 
-				w.logEvent(true, "started pid %d '%s' for the %d time", w.cmd.Process.Pid, w.PathToChildExecutable, w.startCount)
+				w.logEvent(true, "started pid %d '%s'; total start count %d", w.cmd.Process.Pid, w.PathToChildExecutable, w.startCount)
 			}
 
 			select {


### PR DESCRIPTION
# What
add a channel accessible from the outside to signal a process restart
# Why
On a geth restart, multibaas needs to know that it should resubscribe to events